### PR TITLE
Fixing 'module' object has no attribute 'PROTOCOL_SSLv3' Error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dnslib == 0.9.4
-requests == 2.4.3
+requests == 2.6.0
 Twisted == 14.0.2
 python_twitter == 3.1
 certifi


### PR DESCRIPTION
I tried to use Slack as logger when I got the Error.
Using a newer library of 'requests' fixed the problem.