### PR TITLE
Allow honeypy.cfg to have only the logger sections that are required.

### DIFF
--- a/Honey.py
+++ b/Honey.py
@@ -77,21 +77,11 @@ file_log_observer.timeFormat = "%Y-%m-%d %H:%M:%S,%f," + time_zone.rstrip()
 # start logging
 log.startLoggingWithObserver(file_log_observer.emit, False)
 
-if honeypy_config.get('twitter', 'enabled') == 'Yes' or \
-   honeypy_config.get('honeydb', 'enabled') == 'Yes' or \
-   honeypy_config.get('slack', 'enabled') == 'Yes' or \
-   honeypy_config.get('logstash', 'enabled') == 'Yes' or \
-   honeypy_config.get('elasticsearch', 'enabled') == 'Yes' or \
-   honeypy_config.get('telegram', 'enabled') == 'Yes' or \
-   honeypy_config.get('rabbitmq', 'enabled') == 'Yes' or \
-   honeypy_config.get('sumologic', 'enabled') == 'Yes' or \
-   honeypy_config.get('splunk', 'enabled'):
-
-    # tail log file when reactor runs
-    tailer = HoneyPyLogTail(log_path + log_file_name)
-    tailer.config = honeypy_config
-    tailer.useragent = 'HoneyPy (' + version + ')'
-    tailer.start()
+# tail log file when reactor runs
+tailer = HoneyPyLogTail(log_path + log_file_name)
+tailer.config = honeypy_config
+tailer.useragent = 'HoneyPy (' + version + ')'
+tailer.start()
 
 # services object array
 services = []

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -4,7 +4,6 @@ from lib.followtail import FollowTail
 
 class HoneyPyLogTail(FollowTail):
     config = None
-    useragent = None
 
     def lineReceived(self, line):
         parts = line.split()
@@ -52,7 +51,7 @@ class HoneyPyLogTail(FollowTail):
                             self.config.items(section)
                             module_name = "loggers.%s.honeypy_%s" % (section, section)
                             logger_module = import_module(module_name)
-                            logger_module.process(self.config, section, parts, time_parts, self.useragent)
+                            logger_module.process(self.config, section, parts, time_parts)
 
                 except Exception as e:
                     log.msg('Exception: HoneyPyLogTail: {}: {}'.format(str(e), str(parts)))

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -46,9 +46,9 @@ class HoneyPyLogTail(FollowTail):
                 time_parts = parts[1].split(',')
 
                 try:
-                    # iterate through the configured sections
+                    # iterate through the configured sections, but not the main app section
                     for section in self.config.sections():
-                        if self.config.get(section, 'enabled'):
+                        if section != 'honeypy' and self.config.get(section, 'enabled'):
                             self.config.items(section)
                             module_name = "loggers.%s.honeypy_%s" % (section, section)
                             logger_module = import_module(module_name)

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -52,26 +52,13 @@ class HoneyPyLogTail(FollowTail):
 
                 # iterate through the configured sections
                 for section in self.config.sections():
-                    if section in ["twitter", "sumologic"] and self.config.get(section, 'enabled'):
+                    if section in ["slack", "twitter", "sumologic"] and self.config.get(section, 'enabled'):
                         self.config.items(section)
                         module_name = "loggers.%s.honeypy_%s" % (section, section)
                         logger_module = import_module(module_name)
                         logger_module.process(self.config, section, parts, time_parts, self.useragent)
 
                 try:
-
-                    try:
-                        # Slack integration
-                        if self.config.get('slack', 'enabled') == 'Yes':
-                            from loggers.slack.honeypy_slack import post_slack
-
-                            if parts[4] == 'TCP' and parts[5] == 'CONNECT':
-                                post_slack(self.config, parts[8], parts[9])
-                            elif parts[6] == 'RX':
-                                # UDP splits differently (see comment section above)
-                                post_slack(self.config, parts[9], parts[10])
-                    except NoSectionError:
-                        pass
 
                     try:
                         # HoneyDB integration

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -49,39 +49,13 @@ class HoneyPyLogTail(FollowTail):
                 # iterate through the configured sections
                 for section in self.config.sections():
                     #this is a transitional condition
-                    if section in ["splunk", "telegram", "elasticsearch", "logstash", "honeydb", "slack", "twitter", "sumologic"] and self.config.get(section, 'enabled'):
+                    if section in ["rabbitmq", "splunk", "telegram", "elasticsearch", "logstash", "honeydb", "slack", "twitter", "sumologic"] and self.config.get(section, 'enabled'):
                         self.config.items(section)
                         module_name = "loggers.%s.honeypy_%s" % (section, section)
                         logger_module = import_module(module_name)
                         logger_module.process(self.config, section, parts, time_parts, self.useragent)
 
                 try:
-
-                    try:
-                        # Rabbitmq integration.
-                        if self.config.get('rabbitmq', 'enabled') == 'Yes':
-                            from loggers.rabbitmq.honeypy_rabbitmq import post_rabbitmq
-
-                            if parts[4] == 'TCP':
-                                if len(parts) == 11:
-                                    parts.append('')  # no data for CONNECT events
-
-                                post_rabbitmq(self.config.get('rabbitmq', 'url_param'), self.config.get('rabbitmq', 'exchange'),
-                                              self.config.get('rabbitmq', 'routing_key'), parts[0],
-                                              time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5],
-                                              parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
-
-                            else:
-                                # UDP splits differently (see comment section above)
-                                if len(parts) == 12:
-                                    parts.append('')  # no data sent
-
-                                post_rabbitmq(self.config.get('rabbitmq', 'url_param'), self.config.get('rabbitmq', 'exchange'),
-                                              self.config.get('rabbitmq', 'routing_key'), parts[0],
-                                              time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6],
-                                              parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
-                    except NoSectionError:
-                        pass
 
                 except Exception as e:
                     log.msg('Exception: HoneyPyLogTail: {}: {}'.format(str(e), str(parts)))

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -1,5 +1,4 @@
 from importlib import import_module
-from ConfigParser import NoSectionError
 from twisted.python import log
 from lib.followtail import FollowTail
 
@@ -46,16 +45,14 @@ class HoneyPyLogTail(FollowTail):
                 # time_parts[2]: time zone
                 time_parts = parts[1].split(',')
 
-                # iterate through the configured sections
-                for section in self.config.sections():
-                    #this is a transitional condition
-                    if section in ["rabbitmq", "splunk", "telegram", "elasticsearch", "logstash", "honeydb", "slack", "twitter", "sumologic"] and self.config.get(section, 'enabled'):
-                        self.config.items(section)
-                        module_name = "loggers.%s.honeypy_%s" % (section, section)
-                        logger_module = import_module(module_name)
-                        logger_module.process(self.config, section, parts, time_parts, self.useragent)
-
                 try:
+                    # iterate through the configured sections
+                    for section in self.config.sections():
+                        if self.config.get(section, 'enabled'):
+                            self.config.items(section)
+                            module_name = "loggers.%s.honeypy_%s" % (section, section)
+                            logger_module = import_module(module_name)
+                            logger_module.process(self.config, section, parts, time_parts, self.useragent)
 
                 except Exception as e:
                     log.msg('Exception: HoneyPyLogTail: {}: {}'.format(str(e), str(parts)))

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -52,25 +52,13 @@ class HoneyPyLogTail(FollowTail):
 
                 # iterate through the configured sections
                 for section in self.config.sections():
-                    if section == "sumologic" and self.config.get(section, 'enabled'):
+                    if section in ["twitter", "sumologic"] and self.config.get(section, 'enabled'):
                         self.config.items(section)
                         module_name = "loggers.%s.honeypy_%s" % (section, section)
                         logger_module = import_module(module_name)
                         logger_module.process(self.config, section, parts, time_parts, self.useragent)
 
                 try:
-                    # Twitter integration
-                    try:
-                        if self.config.get('twitter', 'enabled') == 'Yes':
-                            from loggers.twitter.honeypy_twitter import post_tweet
-
-                            if parts[4] == 'TCP':
-                                post_tweet(self.config, parts[8], parts[9])
-                            else:
-                                # UDP splits differently (see comment section above)
-                                post_tweet(self.config, parts[9], parts[10])
-                    except NoSectionError:
-                        pass
 
                     try:
                         # Slack integration

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -48,32 +48,14 @@ class HoneyPyLogTail(FollowTail):
 
                 # iterate through the configured sections
                 for section in self.config.sections():
-                    if section in ["honeydb", "slack", "twitter", "sumologic"] and self.config.get(section, 'enabled'):
+                    #this is a transitional condition
+                    if section in ["logstash", "honeydb", "slack", "twitter", "sumologic"] and self.config.get(section, 'enabled'):
                         self.config.items(section)
                         module_name = "loggers.%s.honeypy_%s" % (section, section)
                         logger_module = import_module(module_name)
                         logger_module.process(self.config, section, parts, time_parts, self.useragent)
 
                 try:
-
-                    try:
-                        # Logstash integration
-                        if self.config.get('logstash', 'enabled') == 'Yes':
-                            from loggers.logstash.honeypy_logstash import post_logstash
-
-                            if parts[4] == 'TCP':
-                                if len(parts) == 11:
-                                    parts.append('')  # no data for CONNECT events
-
-                                post_logstash(self.useragent, self.config.get('logstash', 'host'), self.config.get('logstash', 'port'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
-                            else:
-                                # UDP splits differently (see comment section above)
-                                if len(parts) == 12:
-                                    parts.append('')  # no data sent
-
-                                post_logstash(self.useragent, self.config.get('logstash', 'host'), self.config.get('logstash', 'port'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
-                    except NoSectionError:
-                        pass
 
                     try:
                         # Elasticsearch integration

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -49,25 +49,13 @@ class HoneyPyLogTail(FollowTail):
                 # iterate through the configured sections
                 for section in self.config.sections():
                     #this is a transitional condition
-                    if section in ["elasticsearch","logstash", "honeydb", "slack", "twitter", "sumologic"] and self.config.get(section, 'enabled'):
+                    if section in ["telegram", "elasticsearch", "logstash", "honeydb", "slack", "twitter", "sumologic"] and self.config.get(section, 'enabled'):
                         self.config.items(section)
                         module_name = "loggers.%s.honeypy_%s" % (section, section)
                         logger_module = import_module(module_name)
                         logger_module.process(self.config, section, parts, time_parts, self.useragent)
 
                 try:
-
-                    try:
-                        # Telegram integration
-                        if self.config.get('telegram', 'enabled') == 'Yes':
-                            from loggers.telegram.honeypy_telegram import send_telegram_message
-                            if parts[4] == 'TCP':
-                                send_telegram_message(self.config, parts[8], parts[9])
-                            else:
-                                # UDP splits differently (see comment section above)
-                                send_telegram_message(self.config, parts[9], parts[10])
-                    except NoSectionError:
-                        pass
 
                     try:
                         # Splunk

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -1,6 +1,6 @@
+from ConfigParser import NoSectionError
 from twisted.python import log
 from lib.followtail import FollowTail
-
 
 class HoneyPyLogTail(FollowTail):
     config = None
@@ -51,172 +51,200 @@ class HoneyPyLogTail(FollowTail):
 
                 try:
                     # Twitter integration
-                    if self.config.get('twitter', 'enabled') == 'Yes':
-                        from loggers.twitter.honeypy_twitter import post_tweet
+                    try:
+                        if self.config.get('twitter', 'enabled') == 'Yes':
+                            from loggers.twitter.honeypy_twitter import post_tweet
 
-                        if parts[4] == 'TCP':
-                            post_tweet(self.config, parts[8], parts[9])
-                        else:
-                            # UDP splits differently (see comment section above)
-                            post_tweet(self.config, parts[9], parts[10])
+                            if parts[4] == 'TCP':
+                                post_tweet(self.config, parts[8], parts[9])
+                            else:
+                                # UDP splits differently (see comment section above)
+                                post_tweet(self.config, parts[9], parts[10])
+                    except NoSectionError:
+                        pass
 
-                    # Slack integration
-                    if self.config.get('slack', 'enabled') == 'Yes':
-                        from loggers.slack.honeypy_slack import post_slack
+                    try:
+                        # Slack integration
+                        if self.config.get('slack', 'enabled') == 'Yes':
+                            from loggers.slack.honeypy_slack import post_slack
 
-                        if parts[4] == 'TCP' and parts[5] == 'CONNECT':
-                            post_slack(self.config, parts[8], parts[9])
-                        elif parts[6] == 'RX':
-                            # UDP splits differently (see comment section above)
-                            post_slack(self.config, parts[9], parts[10])
+                            if parts[4] == 'TCP' and parts[5] == 'CONNECT':
+                                post_slack(self.config, parts[8], parts[9])
+                            elif parts[6] == 'RX':
+                                # UDP splits differently (see comment section above)
+                                post_slack(self.config, parts[9], parts[10])
+                    except NoSectionError:
+                        pass
 
-                    # HoneyDB integration
-                    if self.config.get('honeydb', 'enabled') == 'Yes':
-                        from loggers.honeydb.honeypy_honeydb import post_log, get_hmac
+                    try:
+                        # HoneyDB integration
+                        if self.config.get('honeydb', 'enabled') == 'Yes':
+                            from loggers.honeydb.honeypy_honeydb import post_log, get_hmac
 
-                        if self.hmac_hash is None:
-                            log.msg('HoneyDB logger: retrieving initial hmac.')
-                            self.got_hmac, self.hmac_hash, self.hmac_message = get_hmac(self.useragent, self.config.get('honeydb', 'hmac_url'), self.config.get('honeydb', 'api_id'), self.config.get('honeydb', 'api_key'))
+                            if self.hmac_hash is None:
+                                log.msg('HoneyDB logger: retrieving initial hmac.')
+                                self.got_hmac, self.hmac_hash, self.hmac_message = get_hmac(self.useragent, self.config.get('honeydb', 'hmac_url'), self.config.get('honeydb', 'api_id'), self.config.get('honeydb', 'api_key'))
 
-                        for i in range(1, 4):
-                            log.msg('HoneyDB logger: post attempt {}.'.format(i))
+                            for i in range(1, 4):
+                                log.msg('HoneyDB logger: post attempt {}.'.format(i))
 
-                            if self.got_hmac:
-                                response = None
+                                if self.got_hmac:
+                                    response = None
 
-                                if parts[4] == 'TCP':
-                                    if len(parts) == 11:
-                                        parts.append('')  # no data for CONNECT events
+                                    if parts[4] == 'TCP':
+                                        if len(parts) == 11:
+                                            parts.append('')  # no data for CONNECT events
 
-                                    response = post_log(self.useragent, self.config.get('honeydb', 'url'), self.hmac_hash, self.hmac_message, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
-
-                                else:
-                                    # UDP splits differently (see comment section above)
-                                    if len(parts) == 12:
-                                        parts.append('')  # no data sent
-
-                                    response = post_log(self.useragent, self.config.get('honeydb', 'url'), self.hmac_hash, self.hmac_message, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
-
-                                if response == 'Success':
-                                    break
-
-                                else:
-                                    if response == 'Invalid HMAC' and i < 3:
-                                        log.msg('HoneyDB logger: hmac invalid, retrieving new hmac.')
-                                        self.got_hmac, self.hmac_hash, self.hmac_message = get_hmac(self.useragent, self.config.get('honeydb', 'hmac_url'), self.config.get('honeydb', 'api_id'), self.config.get('honeydb', 'api_key'))
-
-                                    elif response == 'Invalid HMAC' and i == 3:
-                                        log.msg('HoneyDB logger: hmac invalid, 3 failed attempts, giving up.')
-
-                                    elif i < 3:
-                                        log.msg('HoneyDB logger: {}, make another attempt.'.format(response))
+                                        response = post_log(self.useragent, self.config.get('honeydb', 'url'), self.hmac_hash, self.hmac_message, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
 
                                     else:
-                                        log.msg('HoneyDB logger: {}, 3 failed attempts, giving up.'.format(response))
+                                        # UDP splits differently (see comment section above)
+                                        if len(parts) == 12:
+                                            parts.append('')  # no data sent
 
-                    # Logstash integration
-                    if self.config.get('logstash', 'enabled') == 'Yes':
-                        from loggers.logstash.honeypy_logstash import post_logstash
+                                        response = post_log(self.useragent, self.config.get('honeydb', 'url'), self.hmac_hash, self.hmac_message, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
 
-                        if parts[4] == 'TCP':
-                            if len(parts) == 11:
-                                parts.append('')  # no data for CONNECT events
+                                    if response == 'Success':
+                                        break
 
-                            post_logstash(self.useragent, self.config.get('logstash', 'host'), self.config.get('logstash', 'port'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
-                        else:
-                            # UDP splits differently (see comment section above)
-                            if len(parts) == 12:
-                                parts.append('')  # no data sent
+                                    else:
+                                        if response == 'Invalid HMAC' and i < 3:
+                                            log.msg('HoneyDB logger: hmac invalid, retrieving new hmac.')
+                                            self.got_hmac, self.hmac_hash, self.hmac_message = get_hmac(self.useragent, self.config.get('honeydb', 'hmac_url'), self.config.get('honeydb', 'api_id'), self.config.get('honeydb', 'api_key'))
 
-                            post_logstash(self.useragent, self.config.get('logstash', 'host'), self.config.get('logstash', 'port'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+                                        elif response == 'Invalid HMAC' and i == 3:
+                                            log.msg('HoneyDB logger: hmac invalid, 3 failed attempts, giving up.')
 
-                    # Elasticsearch integration
-                    if self.config.get('elasticsearch', 'enabled') == 'Yes':
-                        from loggers.elasticsearch.honeypy_elasticsearch import post_elasticsearch
+                                        elif i < 3:
+                                            log.msg('HoneyDB logger: {}, make another attempt.'.format(response))
 
-                        if parts[4] == 'TCP':
-                            if len(parts) == 11:
-                                parts.append('')  # no data for CONNECT events
+                                        else:
+                                            log.msg('HoneyDB logger: {}, 3 failed attempts, giving up.'.format(response))
+                    except NoSectionError:
+                        pass
 
-                            post_elasticsearch(self.useragent, self.config.get('elasticsearch', 'es_url'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
-                        else:
-                            # UDP splits differently (see comment section above)
-                            if len(parts) == 12:
-                                parts.append('')  # no data sent
+                    try:
+                        # Logstash integration
+                        if self.config.get('logstash', 'enabled') == 'Yes':
+                            from loggers.logstash.honeypy_logstash import post_logstash
 
-                            post_elasticsearch(self.useragent, self.config.get('elasticsearch', 'es_url'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+                            if parts[4] == 'TCP':
+                                if len(parts) == 11:
+                                    parts.append('')  # no data for CONNECT events
 
-                    # Telegram integration
-                    if self.config.get('telegram', 'enabled') == 'Yes':
-                        from loggers.telegram.honeypy_telegram import send_telegram_message
-                        if parts[4] == 'TCP':
-                            send_telegram_message(self.config, parts[8], parts[9])
-                        else:
-                            # UDP splits differently (see comment section above)
-                            send_telegram_message(self.config, parts[9], parts[10])
+                                post_logstash(self.useragent, self.config.get('logstash', 'host'), self.config.get('logstash', 'port'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+                            else:
+                                # UDP splits differently (see comment section above)
+                                if len(parts) == 12:
+                                    parts.append('')  # no data sent
 
-                    # Elasticsearch integration
-                    if self.config.get('splunk', 'enabled') == 'Yes':
-                        from loggers.splunk.honeypy_splunk import post_splunk
+                                post_logstash(self.useragent, self.config.get('logstash', 'host'), self.config.get('logstash', 'port'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+                    except NoSectionError:
+                        pass
 
-                        url = self.config.get('splunk', 'url')
-                        username = self.config.get('splunk', 'username')
-                        password = self.config.get('splunk', 'password')
+                    try:
+                        # Elasticsearch integration
+                        if self.config.get('elasticsearch', 'enabled') == 'Yes':
+                            from loggers.elasticsearch.honeypy_elasticsearch import post_elasticsearch
 
-                        if parts[4] == 'TCP':
-                            if len(parts) == 11:
-                                parts.append('')  # no data for CONNECT events
+                            if parts[4] == 'TCP':
+                                if len(parts) == 11:
+                                    parts.append('')  # no data for CONNECT events
 
-                            post_splunk(username, password, self.useragent, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
-                        else:
-                            # UDP splits differently (see comment section above)
-                            if len(parts) == 12:
-                                parts.append('')  # no data sent
+                                post_elasticsearch(self.useragent, self.config.get('elasticsearch', 'es_url'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+                            else:
+                                # UDP splits differently (see comment section above)
+                                if len(parts) == 12:
+                                    parts.append('')  # no data sent
 
-                            post_splunk(username, password, self.useragent, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+                                post_elasticsearch(self.useragent, self.config.get('elasticsearch', 'es_url'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+                    except NoSectionError:
+                        pass
 
-		    #sumologic
-                    if self.config.get('sumologic', 'enabled') == 'Yes':
-                        from loggers.sumologic.honeypy_sumologic import post_sumologic
+                    try:
+                        # Telegram integration
+                        if self.config.get('telegram', 'enabled') == 'Yes':
+                            from loggers.telegram.honeypy_telegram import send_telegram_message
+                            if parts[4] == 'TCP':
+                                send_telegram_message(self.config, parts[8], parts[9])
+                            else:
+                                # UDP splits differently (see comment section above)
+                                send_telegram_message(self.config, parts[9], parts[10])
+                    except NoSectionError:
+                        pass
 
-                        url = self.config.get('sumologic', 'url')
-                        custom_source_host = self.config.get('sumologic', 'custom_source_host')
-                        custom_source_name = self.config.get('sumologic', 'custom_source_name')
-                        custom_source_category = self.config.get('sumologic', 'custom_source_category')
+                    try:
+                        # Splunk
+                        if self.config.get('splunk', 'enabled') == 'Yes':
+                            from loggers.splunk.honeypy_splunk import post_splunk
 
-                        if parts[4] == 'TCP':
-                            if len(parts) == 11:
-                                parts.append('')  # no data for CONNECT events
+                            url = self.config.get('splunk', 'url')
+                            username = self.config.get('splunk', 'username')
+                            password = self.config.get('splunk', 'password')
 
-                            post_sumologic(self.useragent, custom_source_host, custom_source_name, custom_source_category, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
-                        else:
-                            # UDP splits differently (see comment section above)
-                            if len(parts) == 12:
-                                parts.append('')  # no data sent
+                            if parts[4] == 'TCP':
+                                if len(parts) == 11:
+                                    parts.append('')  # no data for CONNECT events
 
-                            post_sumologic(self.useragent, custom_source_host, custom_source_name, custom_source_category, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+                                post_splunk(username, password, self.useragent, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+                            else:
+                                # UDP splits differently (see comment section above)
+                                if len(parts) == 12:
+                                    parts.append('')  # no data sent
 
-                    # Rabbitmq integration.
-                    if self.config.get('rabbitmq', 'enabled') == 'Yes':
-                        from loggers.rabbitmq.honeypy_rabbitmq import post_rabbitmq
+                                post_splunk(username, password, self.useragent, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+                    except NoSectionError:
+                        pass
 
-                        if parts[4] == 'TCP':
-                            if len(parts) == 11:
-                                parts.append('')  # no data for CONNECT events
+                    try:
+                        #sumologic
+                        if self.config.get('sumologic', 'enabled') == 'Yes':
+                            from loggers.sumologic.honeypy_sumologic import post_sumologic
 
-                            post_rabbitmq(self.config.get('rabbitmq', 'url_param'), self.config.get('rabbitmq', 'exchange'),
-                                          self.config.get('rabbitmq', 'routing_key'), parts[0],
-                                          time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5],
-                                          parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+                            url = self.config.get('sumologic', 'url')
+                            custom_source_host = self.config.get('sumologic', 'custom_source_host')
+                            custom_source_name = self.config.get('sumologic', 'custom_source_name')
+                            custom_source_category = self.config.get('sumologic', 'custom_source_category')
 
-                        else:
-                            # UDP splits differently (see comment section above)
-                            if len(parts) == 12:
-                                parts.append('')  # no data sent
+                            if parts[4] == 'TCP':
+                                if len(parts) == 11:
+                                    parts.append('')  # no data for CONNECT events
 
-                            post_rabbitmq(self.config.get('rabbitmq', 'url_param'), self.config.get('rabbitmq', 'exchange'),
-                                          self.config.get('rabbitmq', 'routing_key'), parts[0],
-                                          time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6],
-                                          parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+                                post_sumologic(self.useragent, custom_source_host, custom_source_name, custom_source_category, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+                            else:
+                                # UDP splits differently (see comment section above)
+                                if len(parts) == 12:
+                                    parts.append('')  # no data sent
+
+                                post_sumologic(self.useragent, custom_source_host, custom_source_name, custom_source_category, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+                    except NoSectionError:
+                        pass
+
+                    try:
+                        # Rabbitmq integration.
+                        if self.config.get('rabbitmq', 'enabled') == 'Yes':
+                            from loggers.rabbitmq.honeypy_rabbitmq import post_rabbitmq
+
+                            if parts[4] == 'TCP':
+                                if len(parts) == 11:
+                                    parts.append('')  # no data for CONNECT events
+
+                                post_rabbitmq(self.config.get('rabbitmq', 'url_param'), self.config.get('rabbitmq', 'exchange'),
+                                              self.config.get('rabbitmq', 'routing_key'), parts[0],
+                                              time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5],
+                                              parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+
+                            else:
+                                # UDP splits differently (see comment section above)
+                                if len(parts) == 12:
+                                    parts.append('')  # no data sent
+
+                                post_rabbitmq(self.config.get('rabbitmq', 'url_param'), self.config.get('rabbitmq', 'exchange'),
+                                              self.config.get('rabbitmq', 'routing_key'), parts[0],
+                                              time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6],
+                                              parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+                    except NoSectionError:
+                        pass
+
                 except Exception as e:
                     log.msg('Exception: HoneyPyLogTail: {}: {}'.format(str(e), str(parts)))

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -49,36 +49,13 @@ class HoneyPyLogTail(FollowTail):
                 # iterate through the configured sections
                 for section in self.config.sections():
                     #this is a transitional condition
-                    if section in ["telegram", "elasticsearch", "logstash", "honeydb", "slack", "twitter", "sumologic"] and self.config.get(section, 'enabled'):
+                    if section in ["splunk", "telegram", "elasticsearch", "logstash", "honeydb", "slack", "twitter", "sumologic"] and self.config.get(section, 'enabled'):
                         self.config.items(section)
                         module_name = "loggers.%s.honeypy_%s" % (section, section)
                         logger_module = import_module(module_name)
                         logger_module.process(self.config, section, parts, time_parts, self.useragent)
 
                 try:
-
-                    try:
-                        # Splunk
-                        if self.config.get('splunk', 'enabled') == 'Yes':
-                            from loggers.splunk.honeypy_splunk import post_splunk
-
-                            url = self.config.get('splunk', 'url')
-                            username = self.config.get('splunk', 'username')
-                            password = self.config.get('splunk', 'password')
-
-                            if parts[4] == 'TCP':
-                                if len(parts) == 11:
-                                    parts.append('')  # no data for CONNECT events
-
-                                post_splunk(username, password, self.useragent, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
-                            else:
-                                # UDP splits differently (see comment section above)
-                                if len(parts) == 12:
-                                    parts.append('')  # no data sent
-
-                                post_splunk(username, password, self.useragent, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
-                    except NoSectionError:
-                        pass
 
                     try:
                         # Rabbitmq integration.

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -49,32 +49,13 @@ class HoneyPyLogTail(FollowTail):
                 # iterate through the configured sections
                 for section in self.config.sections():
                     #this is a transitional condition
-                    if section in ["logstash", "honeydb", "slack", "twitter", "sumologic"] and self.config.get(section, 'enabled'):
+                    if section in ["elasticsearch","logstash", "honeydb", "slack", "twitter", "sumologic"] and self.config.get(section, 'enabled'):
                         self.config.items(section)
                         module_name = "loggers.%s.honeypy_%s" % (section, section)
                         logger_module = import_module(module_name)
                         logger_module.process(self.config, section, parts, time_parts, self.useragent)
 
                 try:
-
-                    try:
-                        # Elasticsearch integration
-                        if self.config.get('elasticsearch', 'enabled') == 'Yes':
-                            from loggers.elasticsearch.honeypy_elasticsearch import post_elasticsearch
-
-                            if parts[4] == 'TCP':
-                                if len(parts) == 11:
-                                    parts.append('')  # no data for CONNECT events
-
-                                post_elasticsearch(self.useragent, self.config.get('elasticsearch', 'es_url'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
-                            else:
-                                # UDP splits differently (see comment section above)
-                                if len(parts) == 12:
-                                    parts.append('')  # no data sent
-
-                                post_elasticsearch(self.useragent, self.config.get('elasticsearch', 'es_url'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
-                    except NoSectionError:
-                        pass
 
                     try:
                         # Telegram integration

--- a/loggers/elasticsearch/honeypy_elasticsearch.py
+++ b/loggers/elasticsearch/honeypy_elasticsearch.py
@@ -5,9 +5,8 @@
 
 import sys
 import hashlib
-import urllib
-import requests
 from datetime import datetime
+import requests
 from twisted.python import log
 
 # prevent creation of compiled bytecode files
@@ -55,37 +54,37 @@ def process(config, section, parts, time_parts, useragent):
 
 
 def post(useragent, url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
-	# post events to honeydb logger
-	h = hashlib.md5()
-	h.update(data)
+    # post events to honeydb logger
+    h = hashlib.md5()
+    h.update(data)
 
-	#formatting date_time as iso format so that Kibana will recognize it as a date field
-	date_time = datetime.strptime(date_time,"%Y-%m-%d %H:%M:%S").isoformat()
-	
-	headers = { 'User-Agent': useragent, "Content-Type": "application/json" }
-	# applying [:-3] to time to truncate millisecond
-	data    = {
-		'date': date,
-		'time': time,
-		'date_time': date_time,
-		'millisecond': str(millisecond)[:-3],
-		'session': session,
-		'protocol': protocol,
-		'event': event,
-		'local_host': local_host,
-		'local_port': local_port,
-		'service': service,
-		'remote_host': remote_host,
-		'remote_port': remote_port,
-		'data': data,
-		'bytes': str(len(data)),
-		'data_hash': h.hexdigest()
-	}
+    #formatting date_time as iso format so that Kibana will recognize it as a date field
+    date_time = datetime.strptime(date_time, "%Y-%m-%d %H:%M:%S").isoformat()
 
-	try:
-		r       = requests.post(url, headers=headers, json=data, timeout=3)
-		page    = r.text
-		
-		log.msg('Post event to elasticsearch, response: %s' % (str(page).strip()))
-	except Exception as e:
-		log.msg('Error posting to elasticsearch: %s' % (str(e.message).strip()))
+    headers = {'User-Agent': useragent, "Content-Type": "application/json"}
+    # applying [:-3] to time to truncate millisecond
+    data = {
+        'date': date,
+        'time': time,
+        'date_time': date_time,
+        'millisecond': str(millisecond)[:-3],
+        'session': session,
+        'protocol': protocol,
+        'event': event,
+        'local_host': local_host,
+        'local_port': local_port,
+        'service': service,
+        'remote_host': remote_host,
+        'remote_port': remote_port,
+        'data': data,
+        'bytes': str(len(data)),
+        'data_hash': h.hexdigest()
+    }
+
+    try:
+        r = requests.post(url, headers=headers, json=data, timeout=3)
+        page = r.text
+
+        log.msg('Post event to elasticsearch, response: %s' % (str(page).strip()))
+    except Exception as e:
+        log.msg('Error posting to elasticsearch: %s' % (str(e.message).strip()))

--- a/loggers/elasticsearch/honeypy_elasticsearch.py
+++ b/loggers/elasticsearch/honeypy_elasticsearch.py
@@ -13,7 +13,48 @@ from twisted.python import log
 # prevent creation of compiled bytecode files
 sys.dont_write_bytecode = True
 
-def post_elasticsearch(useragent, url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
+def process(config, section, parts, time_parts, useragent):
+        # TCP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin
+        #	parts[3]: session
+        #	parts[4]: protocol
+        #	parts[5]: event
+        #	parts[6]: local_host
+        #	parts[7]: local_port
+        #	parts[8]: service
+        #	parts[9]: remote_host
+        #	parts[10]: remote_port
+        #	parts[11]: data
+        # UDP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin string part
+        #	parts[3]: plugin string part
+        #	parts[4]: session
+        #	parts[5]: protocol
+        #	parts[6]: event
+        #	parts[7]: local_host
+        #	parts[8]: local_port
+        #	parts[9]: service
+        #	parts[10]: remote_host
+        #	parts[11]: remote_port
+        #	parts[12]: data
+    if parts[4] == 'TCP':
+        if len(parts) == 11:
+            parts.append('')  # no data for CONNECT events
+
+        post(useragent, config.get(section, 'es_url'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+    else:
+        # UDP splits differently (see comment section above)
+        if len(parts) == 12:
+            parts.append('')  # no data sent
+
+        post(useragent, config.get(section, 'es_url'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+
+
+def post(useragent, url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
 	# post events to honeydb logger
 	h = hashlib.md5()
 	h.update(data)

--- a/loggers/elasticsearch/honeypy_elasticsearch.py
+++ b/loggers/elasticsearch/honeypy_elasticsearch.py
@@ -12,7 +12,7 @@ from twisted.python import log
 # prevent creation of compiled bytecode files
 sys.dont_write_bytecode = True
 
-def process(config, section, parts, time_parts, useragent):
+def process(config, section, parts, time_parts):
         # TCP
         #	parts[0]: date
         #	parts[1]: time_parts
@@ -44,16 +44,17 @@ def process(config, section, parts, time_parts, useragent):
         if len(parts) == 11:
             parts.append('')  # no data for CONNECT events
 
-        post(useragent, config.get(section, 'es_url'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+        post(config.get(section, 'es_url'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
     else:
         # UDP splits differently (see comment section above)
         if len(parts) == 12:
             parts.append('')  # no data sent
 
-        post(useragent, config.get(section, 'es_url'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+        post(config.get(section, 'es_url'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
 
 
-def post(useragent, url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
+def post(url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
+    useragent = None
     # post events to honeydb logger
     h = hashlib.md5()
     h.update(data)

--- a/loggers/honeydb/honeypy_honeydb.py
+++ b/loggers/honeydb/honeypy_honeydb.py
@@ -5,12 +5,11 @@
 
 import sys
 import hashlib
-import urllib
-import requests
 import itertools
 import operator
 import json
 import random
+import requests
 from uuid import getnode
 from twisted.python import log
 

--- a/loggers/honeydb/honeypy_honeydb.py
+++ b/loggers/honeydb/honeypy_honeydb.py
@@ -17,8 +17,85 @@ from twisted.python import log
 # prevent creation of compiled bytecode files
 sys.dont_write_bytecode = True
 
+
+def process(config, section, parts, time_parts, useragent):
+        # TCP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin
+        #	parts[3]: session
+        #	parts[4]: protocol
+        #	parts[5]: event
+        #	parts[6]: local_host
+        #	parts[7]: local_port
+        #	parts[8]: service
+        #	parts[9]: remote_host
+        #	parts[10]: remote_port
+        #	parts[11]: data
+        # UDP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin string part
+        #	parts[3]: plugin string part
+        #	parts[4]: session
+        #	parts[5]: protocol
+        #	parts[6]: event
+        #	parts[7]: local_host
+        #	parts[8]: local_port
+        #	parts[9]: service
+        #	parts[10]: remote_host
+        #	parts[11]: remote_port
+        #	parts[12]: data
+        # class varaibles for HoneyDB
+    got_hmac = False
+    hmac_hash = None
+    hmac_message = None
+    
+    if hmac_hash is None:
+        log.msg('HoneyDB logger: retrieving initial hmac.')
+        got_hmac, hmac_hash, hmac_message = get_hmac(useragent, config.get('honeydb', 'hmac_url'), config.get('honeydb', 'api_id'), config.get('honeydb', 'api_key'))
+
+    for i in range(1, 4):
+        log.msg('HoneyDB logger: post attempt {}.'.format(i))
+
+        if got_hmac:
+            response = None
+
+            if parts[4] == 'TCP':
+                if len(parts) == 11:
+                    parts.append('')  # no data for CONNECT events
+
+                response = post(useragent, config.get('honeydb', 'url'), hmac_hash, hmac_message, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+
+            else:
+                # UDP splits differently (see comment section above)
+                if len(parts) == 12:
+                    parts.append('')  # no data sent
+
+                response = post(useragent, config.get('honeydb', 'url'), hmac_hash, hmac_message, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+
+            if response == 'Success':
+                break
+
+            else:
+                if response == 'Invalid HMAC' and i < 3:
+                    log.msg('HoneyDB logger: hmac invalid, retrieving new hmac.')
+                    got_hmac, hmac_hash, hmac_message = get_hmac(useragent, config.get('honeydb', 'hmac_url'), config.get('honeydb', 'api_id'), config.get('honeydb', 'api_key'))
+
+                elif response == 'Invalid HMAC' and i == 3:
+                    log.msg('HoneyDB logger: hmac invalid, 3 failed attempts, giving up.')
+
+                elif i < 3:
+                    log.msg('HoneyDB logger: {}, make another attempt.'.format(response))
+
+                else:
+                    log.msg('HoneyDB logger: {}, 3 failed attempts, giving up.'.format(response))
+
+
+
+
 def get_hmac(useragent, url, api_id, api_key):
-	headers = { 'User-Agent': useragent, 'X-HoneyDb-ApiId': api_id, 'X-HoneyDb-ApiKey': api_key }
+	headers = {'User-Agent': useragent, 'X-HoneyDb-ApiId': api_id, 'X-HoneyDb-ApiKey': api_key}
 	url     = 'https://riskdiscovery.com/honeydb/api/hmac'
 
 	try:
@@ -35,7 +112,7 @@ def get_hmac(useragent, url, api_id, api_key):
 		log.msg('HoneyDB logger: Error retrieving hmac: %s' % (str(e.message).strip()))
 		return False, None, None
 
-def post_log(useragent, url, hmac_hash, hmac_message, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
+def post(useragent, url, hmac_hash, hmac_message, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
 	# post events to honeydb logger
 	h = hashlib.md5()
 	h.update(data)
@@ -69,7 +146,7 @@ def post_log(useragent, url, hmac_hash, hmac_message, date, time, date_time, mil
 	}
 
 	try:
-		r        = requests.post(url, headers=headers, json=data, timeout=10)
+		r = requests.post(url, headers=headers, json=data, timeout=10)
 		response = json.loads(r.text)
 
 		log.msg('Post event to honeydb, response: %s' % (str(response).strip().replace('\n', ' ')))

--- a/loggers/honeydb/honeypy_honeydb.py
+++ b/loggers/honeydb/honeypy_honeydb.py
@@ -50,7 +50,7 @@ def process(config, section, parts, time_parts, useragent):
     got_hmac = False
     hmac_hash = None
     hmac_message = None
-    
+
     if hmac_hash is None:
         log.msg('HoneyDB logger: retrieving initial hmac.')
         got_hmac, hmac_hash, hmac_message = get_hmac(useragent, config.get('honeydb', 'hmac_url'), config.get('honeydb', 'api_id'), config.get('honeydb', 'api_key'))
@@ -95,65 +95,65 @@ def process(config, section, parts, time_parts, useragent):
 
 
 def get_hmac(useragent, url, api_id, api_key):
-	headers = {'User-Agent': useragent, 'X-HoneyDb-ApiId': api_id, 'X-HoneyDb-ApiKey': api_key}
-	url     = 'https://riskdiscovery.com/honeydb/api/hmac'
+    headers = {'User-Agent': useragent, 'X-HoneyDb-ApiId': api_id, 'X-HoneyDb-ApiKey': api_key}
+    url = 'https://riskdiscovery.com/honeydb/api/hmac'
 
-	try:
-		r = requests.get(url, headers=headers, timeout=3)
-		j = json.loads(r.text)
-		
-		if 'Success' == j['status']:
-			log.msg('HoneyDB logger: hmac received with message: {}'.format(j['hmac_message']))
-			return True, j['hmac_hash'], j['hmac_message']
-		else:
-			raise Exception(j['status'])
-		
-	except Exception as e:
-		log.msg('HoneyDB logger: Error retrieving hmac: %s' % (str(e.message).strip()))
-		return False, None, None
+    try:
+        r = requests.get(url, headers=headers, timeout=3)
+        j = json.loads(r.text)
+
+        if j['status'] == 'Success':
+            log.msg('HoneyDB logger: hmac received with message: {}'.format(j['hmac_message']))
+            return True, j['hmac_hash'], j['hmac_message']
+        else:
+            raise Exception(j['status'])
+
+    except Exception as e:
+        log.msg('HoneyDB logger: Error retrieving hmac: %s' % (str(e.message).strip()))
+        return False, None, None
 
 def post(useragent, url, hmac_hash, hmac_message, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
-	# post events to honeydb logger
-	h = hashlib.md5()
-	h.update(data)
+    # post events to honeydb logger
+    h = hashlib.md5()
+    h.update(data)
 
-	mac_addr = ':'.join((itertools.starmap(operator.add, zip(*([iter("%012X" % getnode())] * 2)))))
-	urls     = ('https://service.us.apiconnect.ibmcloud.com/gws/apigateway/api/046b612677d0c8b57420ea0e9b3cc4960a21b6bfea00a0a22a63ddb81aae64ab/honeydb/collector',
-				'https://z17veyvn82.execute-api.us-east-1.amazonaws.com/prod/collector')
-	url      = random.choice(urls)
+    mac_addr = ':'.join((itertools.starmap(operator.add, zip(*([iter("%012X" % getnode())] * 2)))))
+    urls = ('https://service.us.apiconnect.ibmcloud.com/gws/apigateway/api/046b612677d0c8b57420ea0e9b3cc4960a21b6bfea00a0a22a63ddb81aae64ab/honeydb/collector',
+            'https://z17veyvn82.execute-api.us-east-1.amazonaws.com/prod/collector')
+    url = random.choice(urls)
 
-	headers = { 'User-Agent': useragent, "Content-Type": "application/json" }
-	# applying [:-3] to time to truncate millisecond
-	data    = {
-		'date': date,
-		'time': time,
-		'date_time': date_time,
-		'millisecond': str(millisecond)[:-3],
-		'hmac_hash': hmac_hash,
-		'hmac_message': hmac_message,
-		'session': session,
-		'protocol': protocol,
-		'event': event,
-		'local_host': local_host,
-		'local_port': local_port,
-		'service': service,
-		'remote_host': remote_host,
-		'remote_port': remote_port,
-		'data': data,
-		'bytes': str(len(data)),
-		'data_hash': h.hexdigest(),
-		'node': mac_addr
-	}
+    headers = {'User-Agent': useragent, "Content-Type": "application/json"}
+    # applying [:-3] to time to truncate millisecond
+    data = {
+        'date': date,
+        'time': time,
+        'date_time': date_time,
+        'millisecond': str(millisecond)[:-3],
+        'hmac_hash': hmac_hash,
+        'hmac_message': hmac_message,
+        'session': session,
+        'protocol': protocol,
+        'event': event,
+        'local_host': local_host,
+        'local_port': local_port,
+        'service': service,
+        'remote_host': remote_host,
+        'remote_port': remote_port,
+        'data': data,
+        'bytes': str(len(data)),
+        'data_hash': h.hexdigest(),
+        'node': mac_addr
+    }
 
-	try:
-		r = requests.post(url, headers=headers, json=data, timeout=10)
-		response = json.loads(r.text)
+    try:
+        r = requests.post(url, headers=headers, json=data, timeout=10)
+        response = json.loads(r.text)
 
-		log.msg('Post event to honeydb, response: %s' % (str(response).strip().replace('\n', ' ')))
+        log.msg('Post event to honeydb, response: %s' % (str(response).strip().replace('\n', ' ')))
 
-		return response['status']
+        return response['status']
 
-	except Exception as e:
-		log.msg('HoneyDB logger, post error: %s' % (str(e.message).strip().replace('\n', ' ')))
+    except Exception as e:
+        log.msg('HoneyDB logger, post error: %s' % (str(e.message).strip().replace('\n', ' ')))
 
-		return 'Error'
+        return 'Error'

--- a/loggers/logstash/honeypy_logstash.py
+++ b/loggers/logstash/honeypy_logstash.py
@@ -12,7 +12,7 @@ from twisted.python import log
 # prevent creation of compiled bytecode files
 sys.dont_write_bytecode = True
 
-def process(config, section, parts, time_parts, useragent):
+def process(config, section, parts, time_parts):
         # TCP
         #	parts[0]: date
         #	parts[1]: time_parts

--- a/loggers/logstash/honeypy_logstash.py
+++ b/loggers/logstash/honeypy_logstash.py
@@ -12,7 +12,49 @@ from twisted.python import log
 # prevent creation of compiled bytecode files
 sys.dont_write_bytecode = True
 
-def post_logstash(useragent, host, port, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
+def process(config, section, parts, time_parts, useragent):
+        # TCP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin
+        #	parts[3]: session
+        #	parts[4]: protocol
+        #	parts[5]: event
+        #	parts[6]: local_host
+        #	parts[7]: local_port
+        #	parts[8]: service
+        #	parts[9]: remote_host
+        #	parts[10]: remote_port
+        #	parts[11]: data
+        # UDP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin string part
+        #	parts[3]: plugin string part
+        #	parts[4]: session
+        #	parts[5]: protocol
+        #	parts[6]: event
+        #	parts[7]: local_host
+        #	parts[8]: local_port
+        #	parts[9]: service
+        #	parts[10]: remote_host
+        #	parts[11]: remote_port
+        #	parts[12]: data
+
+    if parts[4] == 'TCP':
+        if len(parts) == 11:
+            parts.append('')  # no data for CONNECT events
+
+        post(useragent, config.get(section, 'host'), config.get(section, 'port'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+    else:
+        # UDP splits differently (see comment section above)
+        if len(parts) == 12:
+            parts.append('')  # no data sent
+
+        post(useragent, config.get(section, 'host'), config.get(section, 'port'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+
+
+def post(useragent, host, port, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
 	# post events to honeydb logger
 	h = hashlib.md5()
 	h.update(data)

--- a/loggers/logstash/honeypy_logstash.py
+++ b/loggers/logstash/honeypy_logstash.py
@@ -45,53 +45,49 @@ def process(config, section, parts, time_parts, useragent):
         if len(parts) == 11:
             parts.append('')  # no data for CONNECT events
 
-        post(useragent, config.get(section, 'host'), config.get(section, 'port'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+        post(config.get(section, 'host'), config.get(section, 'port'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
     else:
         # UDP splits differently (see comment section above)
         if len(parts) == 12:
             parts.append('')  # no data sent
 
-        post(useragent, config.get(section, 'host'), config.get(section, 'port'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+        post(config.get(section, 'host'), config.get(section, 'port'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
 
 
-def post(useragent, host, port, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
-	# post events to honeydb logger
-	h = hashlib.md5()
-	h.update(data)
+def post(host, port, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
+    # post events to honeydb logger
+    h = hashlib.md5()
+    h.update(data)
 
-	headers = { 'User-Agent': useragent }
-	# applying [:-3] to time to truncate millisecond
-	data = {
-		'date': date,
-		'time': time,
-		'date_time': date_time,
-		'millisecond': str(millisecond)[:-3],
-		'session': session,
-		'protocol': protocol,
-		'event': event,
-		'local_host': local_host,
-		'local_port': local_port,
-		'service': service,
-		'remote_host': remote_host,
-		'remote_port': remote_port,
-		'data': data,
-		'bytes': str(len(data)),
-		'data_hash': h.hexdigest()
-	}
+    # applying [:-3] to time to truncate millisecond
+    data = {
+        'date': date,
+        'time': time,
+        'date_time': date_time,
+        'millisecond': str(millisecond)[:-3],
+        'session': session,
+        'protocol': protocol,
+        'event': event,
+        'local_host': local_host,
+        'local_port': local_port,
+        'service': service,
+        'remote_host': remote_host,
+        'remote_port': remote_port,
+        'data': data,
+        'bytes': str(len(data)),
+        'data_hash': h.hexdigest()
+    }
 
-	try:
-		sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect((host, int(port)))
+        bytes_sent = sock.send(json.dumps(data))
+        sock.close()
 
-		sock.connect((host, int(port)))
-		
-		bytes_sent = sock.send(json.dumps(data))
+        log.msg('Post event to logstash! (%s bytes)' % str(bytes_sent))
 
-		sock.close()
+    except socket.error, msg:
+        log.msg('[ERROR] post_logstash, socket.error: %s' % msg[1])
 
-		log.msg('Post event to logstash! (%s bytes)' % str(bytes_sent))
-
-	except socket.error, msg:
-			log.msg('[ERROR] post_logstash, socket.error: %s' % msg[1])
-
-	except Exception as e:
-		log.msg('Error posting to logstash: %s' % (str(e.message).strip()))
+    except Exception as e:
+        log.msg('Error posting to logstash: %s' % (str(e.message).strip()))

--- a/loggers/rabbitmq/honeypy_rabbitmq.py
+++ b/loggers/rabbitmq/honeypy_rabbitmq.py
@@ -48,16 +48,14 @@ def process(config, section, parts, time_parts, useragent):
         if len(parts) == 11:
             parts.append('')  # no data for CONNECT events
 
-        post(config.get(section, 'url_param'), config.get(section, 'exchange'), config.get(section, 'routing_key'), 
-                            parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+        post(config.get(section, 'url_param'), config.get(section, 'exchange'), config.get(section, 'routing_key'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
 
     else:
         # UDP splits differently (see comment section above)
         if len(parts) == 12:
             parts.append('')  # no data sent
 
-        post(config.get(section, 'url_param'), config.get(section, 'exchange'), config.get(section, 'routing_key'), 
-                              parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+        post(config.get(section, 'url_param'), config.get(section, 'exchange'), config.get(section, 'routing_key'), parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
 
 
 def post(url_param, exchange, routing_key, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):

--- a/loggers/rabbitmq/honeypy_rabbitmq.py
+++ b/loggers/rabbitmq/honeypy_rabbitmq.py
@@ -15,7 +15,7 @@ import pika
 # prevent creation of compiled bytecode files
 sys.dont_write_bytecode = True
 
-def process(config, section, parts, time_parts, useragent):
+def process(config, section, parts, time_parts):
         # TCP
         #	parts[0]: date
         #	parts[1]: time_parts

--- a/loggers/slack/honeypy_slack.py
+++ b/loggers/slack/honeypy_slack.py
@@ -10,12 +10,47 @@ from twisted.python import log
 # prevent creation of compiled bytecode files
 sys.dont_write_bytecode = True
 
-def post_slack(honeypycfg, service, clientip):
-    headers = { 'Content-type': 'application/json', 'User-Agent': honeypycfg.get('honeypy', 'useragent') }
-    data    = '{"text": "' + honeypycfg.get('honeypy', 'nodename') + ': Possible *' + service + '* attack from ' + clientip + ' <https://riskdiscovery.com/honeydb/#host/' + clientip + '>"}'
+def process(config, section, parts, time_parts, useragent):
+        # TCP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin
+        #	parts[3]: session
+        #	parts[4]: protocol
+        #	parts[5]: event
+        #	parts[6]: local_host
+        #	parts[7]: local_port
+        #	parts[8]: service
+        #	parts[9]: remote_host
+        #	parts[10]: remote_port
+        #	parts[11]: data
+        # UDP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin string part
+        #	parts[3]: plugin string part
+        #	parts[4]: session
+        #	parts[5]: protocol
+        #	parts[6]: event
+        #	parts[7]: local_host
+        #	parts[8]: local_port
+        #	parts[9]: service
+        #	parts[10]: remote_host
+        #	parts[11]: remote_port
+        #	parts[12]: data
 
-    url     = honeypycfg.get('slack', 'webhook_url')
-    r       = requests.post(url, headers=headers, data=data, timeout=3)
+    if parts[4] == 'TCP' and parts[5] == 'CONNECT':
+        post(config, parts[8], parts[9])
+    elif parts[6] == 'RX':
+        # UDP splits differently (see comment section above)
+        post(config, parts[9], parts[10])
+
+def post(honeypycfg, service, clientip):
+    headers = {'Content-type': 'application/json', 'User-Agent': honeypycfg.get('honeypy', 'useragent')}
+    data = '{"text": "' + honeypycfg.get('honeypy', 'nodename') + ': Possible *' + service + '* attack from ' + clientip + ' <https://riskdiscovery.com/honeydb/#host/' + clientip + '>"}'
+
+    url = honeypycfg.get('slack', 'webhook_url')
+    r = requests.post(url, headers=headers, data=data, timeout=3)
 
     if r.status_code != requests.codes.ok:
         log.msg('Error posting to Slack: %s' % str(r.status_code))

--- a/loggers/slack/honeypy_slack.py
+++ b/loggers/slack/honeypy_slack.py
@@ -10,7 +10,7 @@ from twisted.python import log
 # prevent creation of compiled bytecode files
 sys.dont_write_bytecode = True
 
-def process(config, section, parts, time_parts, useragent):
+def process(config, section, parts, time_parts):
         # TCP
         #	parts[0]: date
         #	parts[1]: time_parts
@@ -46,7 +46,8 @@ def process(config, section, parts, time_parts, useragent):
         post(config, parts[9], parts[10])
 
 def post(honeypycfg, service, clientip):
-    headers = {'Content-type': 'application/json', 'User-Agent': honeypycfg.get('honeypy', 'useragent')}
+    useragent = None
+    headers = {'Content-type': 'application/json', 'User-Agent': useragent}
     data = '{"text": "' + honeypycfg.get('honeypy', 'nodename') + ': Possible *' + service + '* attack from ' + clientip + ' <https://riskdiscovery.com/honeydb/#host/' + clientip + '>"}'
 
     url = honeypycfg.get('slack', 'webhook_url')

--- a/loggers/splunk/honeypy_splunk.py
+++ b/loggers/splunk/honeypy_splunk.py
@@ -4,10 +4,9 @@
 
 import sys
 import hashlib
-import urllib
-import requests
 from datetime import datetime
 from twisted.python import log
+import requests
 
 # prevent creation of compiled bytecode files
 sys.dont_write_bytecode = True
@@ -58,35 +57,35 @@ def process(config, section, parts, time_parts, useragent):
 
 
 def post(username, password, useragent, url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
-	h = hashlib.md5()
-	h.update(data)
+    h = hashlib.md5()
+    h.update(data)
 
-	date_time = datetime.strptime(date_time, "%Y-%m-%d %H:%M:%S").isoformat()
+    date_time = datetime.strptime(date_time, "%Y-%m-%d %H:%M:%S").isoformat()
 
-	headers = { 'User-Agent': useragent, "Content-Type": "application/json" }
-	# applying [:-3] to time to truncate millisecond
-	data    = {
-		'date': date,
-		'time': time,
-		'date_time': date_time,
-		'millisecond': str(millisecond)[:-3],
-		'session': session,
-		'protocol': protocol,
-		'event': event,
-		'local_host': local_host,
-		'local_port': local_port,
-		'service': service,
-		'remote_host': remote_host,
-		'remote_port': remote_port,
-		'data': data,
-		'bytes': str(len(data)),
-		'data_hash': h.hexdigest()
-	}
+    headers = {'User-Agent': useragent, "Content-Type": "application/json"}
+    # applying [:-3] to time to truncate millisecond
+    data = {
+        'date': date,
+        'time': time,
+        'date_time': date_time,
+        'millisecond': str(millisecond)[:-3],
+        'session': session,
+        'protocol': protocol,
+        'event': event,
+        'local_host': local_host,
+        'local_port': local_port,
+        'service': service,
+        'remote_host': remote_host,
+        'remote_port': remote_port,
+        'data': data,
+        'bytes': str(len(data)),
+        'data_hash': h.hexdigest()
+    }
 
-	try:
-		r       = requests.post(url, headers=headers, data=data, auth=(username, password), verify=False, timeout=3)
-		page    = r.text
+    try:
+        r = requests.post(url, headers=headers, data=data, auth=(username, password), verify=False, timeout=3)
+        page = r.text
 
-		log.msg('Post event to splunk, response: %s' % (str(page).strip()))
-	except Exception as e:
-		log.msg('Error posting to splunk: %s' % (str(e.message).strip()))
+        log.msg('Post event to splunk, response: %s' % (str(page).strip()))
+    except Exception as e:
+        log.msg('Error posting to splunk: %s' % (str(e.message).strip()))

--- a/loggers/splunk/honeypy_splunk.py
+++ b/loggers/splunk/honeypy_splunk.py
@@ -12,11 +12,56 @@ from twisted.python import log
 # prevent creation of compiled bytecode files
 sys.dont_write_bytecode = True
 
-def post_splunk(username, password, useragent, url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
+def process(config, section, parts, time_parts, useragent):
+        # TCP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin
+        #	parts[3]: session
+        #	parts[4]: protocol
+        #	parts[5]: event
+        #	parts[6]: local_host
+        #	parts[7]: local_port
+        #	parts[8]: service
+        #	parts[9]: remote_host
+        #	parts[10]: remote_port
+        #	parts[11]: data
+        # UDP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin string part
+        #	parts[3]: plugin string part
+        #	parts[4]: session
+        #	parts[5]: protocol
+        #	parts[6]: event
+        #	parts[7]: local_host
+        #	parts[8]: local_port
+        #	parts[9]: service
+        #	parts[10]: remote_host
+        #	parts[11]: remote_port
+        #	parts[12]: data
+    url = config.get(section, 'url')
+    username = config.get(section, 'username')
+    password = config.get(section, 'password')
+
+    if parts[4] == 'TCP':
+        if len(parts) == 11:
+            parts.append('')  # no data for CONNECT events
+
+        post(username, password, useragent, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+    else:
+        # UDP splits differently (see comment section above)
+        if len(parts) == 12:
+            parts.append('')  # no data sent
+
+        post(username, password, useragent, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+
+
+def post(username, password, useragent, url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
 	h = hashlib.md5()
 	h.update(data)
 
-	date_time = datetime.strptime(date_time,"%Y-%m-%d %H:%M:%S").isoformat()
+	date_time = datetime.strptime(date_time, "%Y-%m-%d %H:%M:%S").isoformat()
 
 	headers = { 'User-Agent': useragent, "Content-Type": "application/json" }
 	# applying [:-3] to time to truncate millisecond

--- a/loggers/splunk/honeypy_splunk.py
+++ b/loggers/splunk/honeypy_splunk.py
@@ -11,7 +11,7 @@ import requests
 # prevent creation of compiled bytecode files
 sys.dont_write_bytecode = True
 
-def process(config, section, parts, time_parts, useragent):
+def process(config, section, parts, time_parts):
         # TCP
         #	parts[0]: date
         #	parts[1]: time_parts
@@ -47,16 +47,17 @@ def process(config, section, parts, time_parts, useragent):
         if len(parts) == 11:
             parts.append('')  # no data for CONNECT events
 
-        post(username, password, useragent, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+        post(password, useragent, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
     else:
         # UDP splits differently (see comment section above)
         if len(parts) == 12:
             parts.append('')  # no data sent
 
-        post(username, password, useragent, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+        post(username, password, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
 
 
-def post(username, password, useragent, url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
+def post(username, password, url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
+    useragent = None
     h = hashlib.md5()
     h.update(data)
 

--- a/loggers/sumologic/honeypy_sumologic.py
+++ b/loggers/sumologic/honeypy_sumologic.py
@@ -10,7 +10,7 @@ from twisted.python import log
 # prevent creation of compiled bytecode files
 sys.dont_write_bytecode = True
 
-def process(config, section, parts, time_parts, useragent):
+def process(config, section, parts, time_parts):
         # TCP
         #	parts[0]: date
         #	parts[1]: time_parts
@@ -47,16 +47,17 @@ def process(config, section, parts, time_parts, useragent):
         if len(parts) == 11:
             parts.append('')  # no data for CONNECT events
 
-        post(useragent, custom_source_host, custom_source_name, custom_source_category, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+        post(custom_source_host, custom_source_name, custom_source_category, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
     else:
         # UDP splits differently (see comment section above)
         if len(parts) == 12:
             parts.append('')  # no data sent
 
-        post(useragent, custom_source_host, custom_source_name, custom_source_category, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
+        post(custom_source_host, custom_source_name, custom_source_category, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
 
 
-def post(useragent, custom_source_host, custom_source_name, custom_source_category, url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
+def post(custom_source_host, custom_source_name, custom_source_category, url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
+    useragent = None
     h = hashlib.md5()
     h.update(data)
 

--- a/loggers/sumologic/honeypy_sumologic.py
+++ b/loggers/sumologic/honeypy_sumologic.py
@@ -1,57 +1,101 @@
 # HoneyPy Copyright (C) 2013-2017 foospidy
 # https://github.com/foospidy/HoneyPy
 # See LICENSE for details
-
 import sys
 import hashlib
-import urllib
-import requests
 from datetime import datetime
+import requests
 from twisted.python import log
 
 # prevent creation of compiled bytecode files
 sys.dont_write_bytecode = True
 
-def post_sumologic(useragent, custom_source_host, custom_source_name, custom_source_category, url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
-	h = hashlib.md5()
-	h.update(data)
+def process(config, section, parts, time_parts, useragent):
+        # TCP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin
+        #	parts[3]: session
+        #	parts[4]: protocol
+        #	parts[5]: event
+        #	parts[6]: local_host
+        #	parts[7]: local_port
+        #	parts[8]: service
+        #	parts[9]: remote_host
+        #	parts[10]: remote_port
+        #	parts[11]: data
+        # UDP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin string part
+        #	parts[3]: plugin string part
+        #	parts[4]: session
+        #	parts[5]: protocol
+        #	parts[6]: event
+        #	parts[7]: local_host
+        #	parts[8]: local_port
+        #	parts[9]: service
+        #	parts[10]: remote_host
+        #	parts[11]: remote_port
+        #	parts[12]: data
+    url = config.get(section, 'url')
+    custom_source_host = config.get(section, 'custom_source_host')
+    custom_source_name = config.get(section, 'custom_source_name')
+    custom_source_category = config.get(section, 'custom_source_category')
 
-	date_time = datetime.strptime(date_time,"%Y-%m-%d %H:%M:%S").isoformat()
+    if parts[4] == 'TCP':
+        if len(parts) == 11:
+            parts.append('')  # no data for CONNECT events
 
-	headers = { 'User-Agent': useragent, "Content-Type": "application/json" }
+        post(useragent, custom_source_host, custom_source_name, custom_source_category, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11])
+    else:
+        # UDP splits differently (see comment section above)
+        if len(parts) == 12:
+            parts.append('')  # no data sent
 
-	if custom_source_host :
-		headers.update({'X-Sumo-Host' : custom_source_host})
+        post(useragent, custom_source_host, custom_source_name, custom_source_category, url, parts[0], time_parts[0], parts[0] + ' ' + time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12])
 
-        if custom_source_name :
-                headers.update({'X-Sumo-Name' : custom_source_name})
 
-        if custom_source_category :
-                headers.update({'X-Sumo-Category' : custom_source_category})
+def post(useragent, custom_source_host, custom_source_name, custom_source_category, url, date, time, date_time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data):
+    h = hashlib.md5()
+    h.update(data)
 
-	# applying [:-3] to time to truncate millisecond
-	data    = {
-		'date': date,
-		'time': time,
-		'date_time': date_time,
-		'millisecond': str(millisecond)[:-3],
-		'session': session,
-		'protocol': protocol,
-		'event': event,
-		'local_host': local_host,
-		'local_port': local_port,
-		'service': service,
-		'remote_host': remote_host,
-		'remote_port': remote_port,
-		'data': data,
-		'bytes': str(len(data)),
-		'data_hash': h.hexdigest()
-	}
+    date_time = datetime.strptime(date_time, "%Y-%m-%d %H:%M:%S").isoformat()
 
-	try:
-		r       = requests.post(url, headers=headers, json=data, verify=True, timeout=3)
-		page    = r.text
+    headers = {'User-Agent': useragent, "Content-Type": "application/json"}
 
-		log.msg('Post event to sumologic, response: %s' % (str(page).strip()))
-	except Exception as e:
-		log.msg('Error posting to sumologic: %s' % (str(e.message).strip()))
+    if custom_source_host:
+        headers.update({'X-Sumo-Host' : custom_source_host})
+
+        if custom_source_name:
+            headers.update({'X-Sumo-Name' : custom_source_name})
+
+        if custom_source_category:
+            headers.update({'X-Sumo-Category' : custom_source_category})
+
+    # applying [:-3] to time to truncate millisecond
+    data = {
+        'date': date,
+        'time': time,
+        'date_time': date_time,
+        'millisecond': str(millisecond)[:-3],
+        'session': session,
+        'protocol': protocol,
+        'event': event,
+        'local_host': local_host,
+        'local_port': local_port,
+        'service': service,
+        'remote_host': remote_host,
+        'remote_port': remote_port,
+        'data': data,
+        'bytes': str(len(data)),
+        'data_hash': h.hexdigest()
+    }
+
+    try:
+        r = requests.post(url, headers=headers, json=data, verify=True, timeout=3)
+        page = r.text
+        log.msg('Post event to sumologic, response: %s' % (str(page).strip()))
+    except Exception as e:
+        log.msg('Error posting to sumologic: %s' % (str(e.message).strip()))
+ 

--- a/loggers/telegram/honeypy_telegram.py
+++ b/loggers/telegram/honeypy_telegram.py
@@ -8,7 +8,7 @@ import urllib3
 import certifi
 
 
-def process(config, section, parts, time_parts, useragent):
+def process(config, section, parts, time_parts):
         # TCP
         #	parts[0]: date
         #	parts[1]: time_parts

--- a/loggers/telegram/honeypy_telegram.py
+++ b/loggers/telegram/honeypy_telegram.py
@@ -9,6 +9,41 @@ import sys
 import json
 from twisted.python import log
 
+def process(config, section, parts, time_parts, useragent):
+        # TCP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin
+        #	parts[3]: session
+        #	parts[4]: protocol
+        #	parts[5]: event
+        #	parts[6]: local_host
+        #	parts[7]: local_port
+        #	parts[8]: service
+        #	parts[9]: remote_host
+        #	parts[10]: remote_port
+        #	parts[11]: data
+        # UDP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin string part
+        #	parts[3]: plugin string part
+        #	parts[4]: session
+        #	parts[5]: protocol
+        #	parts[6]: event
+        #	parts[7]: local_host
+        #	parts[8]: local_port
+        #	parts[9]: service
+        #	parts[10]: remote_host
+        #	parts[11]: remote_port
+        #	parts[12]: data
+ 
+    if parts[4] == 'TCP':
+        post(config, parts[8], parts[9])
+    else:
+        # UDP splits differently (see comment section above)
+        post(config, parts[9], parts[10])
+
 def get_chat_id(bot_id):
     try:
         https = urllib3.PoolManager(cert_reqs='CERT_REQUIRED', ca_certs=certifi.where())
@@ -19,7 +54,7 @@ def get_chat_id(bot_id):
     except urllib3.exceptions.SSLError as err:
         print('[ERROR] Telegram SSL error', err)
 
-def send_telegram_message(honeypycfg, service, clientip):
+def post(honeypycfg, service, clientip):
     bot_id = honeypycfg.get('telegram', 'bot_id')
     message = service + ' Possible '  + service + ' attack from ' + clientip + ' https://riskdiscovery.com/honeydb/#host/' + clientip
     chat_id = get_chat_id(bot_id)

--- a/loggers/telegram/honeypy_telegram.py
+++ b/loggers/telegram/honeypy_telegram.py
@@ -3,11 +3,10 @@
 # See LICENSE for details
 # HoneyPy telegram module by aancw
 
+import json
 import urllib3
 import certifi
-import sys
-import json
-from twisted.python import log
+
 
 def process(config, section, parts, time_parts, useragent):
         # TCP
@@ -37,7 +36,7 @@ def process(config, section, parts, time_parts, useragent):
         #	parts[10]: remote_host
         #	parts[11]: remote_port
         #	parts[12]: data
- 
+
     if parts[4] == 'TCP':
         post(config, parts[8], parts[9])
     else:

--- a/loggers/twitter/honeypy_twitter.py
+++ b/loggers/twitter/honeypy_twitter.py
@@ -7,17 +7,53 @@ from twitter import Twitter
 from twitter.oauth import OAuth
 from twisted.python import log
 
-def post_tweet(honeypycfg, service, clientip):
+def process(config, section, parts, time_parts, useragent):
+        # TCP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin
+        #	parts[3]: session
+        #	parts[4]: protocol
+        #	parts[5]: event
+        #	parts[6]: local_host
+        #	parts[7]: local_port
+        #	parts[8]: service
+        #	parts[9]: remote_host
+        #	parts[10]: remote_port
+        #	parts[11]: data
+        # UDP
+        #	parts[0]: date
+        #	parts[1]: time_parts
+        #	parts[2]: plugin string part
+        #	parts[3]: plugin string part
+        #	parts[4]: session
+        #	parts[5]: protocol
+        #	parts[6]: event
+        #	parts[7]: local_host
+        #	parts[8]: local_port
+        #	parts[9]: service
+        #	parts[10]: remote_host
+        #	parts[11]: remote_port
+        #	parts[12]: data
 
-	ck = honeypycfg.get('twitter', 'consumerkey')
-	cs = honeypycfg.get('twitter', 'consumersecret')
-	ot = honeypycfg.get('twitter', 'oauthtoken')
-	os = honeypycfg.get('twitter', 'oauthsecret')
+    if parts[4] == 'TCP':
+        post(config, parts[8], parts[9])
+    else:
+        # UDP splits differently (see comment section above)
+        post(config, parts[9], parts[10])
 
-	t        = Twitter(auth=OAuth(ot, os, ck, cs))
-	nodename = honeypycfg.get('honeypy', 'nodename')
 
-	try:
-		t.statuses.update(status=nodename + ': #' + service + ' Possible '  + service + ' attack from ' + clientip + ' https://riskdiscovery.com/honeydb/#host/' + clientip)
-	except Exception, err:
-		log.msg('Error posting to Twitter: %s' % err)
+def post(honeypycfg, service, clientip):
+
+    ck = honeypycfg.get('twitter', 'consumerkey')
+    cs = honeypycfg.get('twitter', 'consumersecret')
+    ot = honeypycfg.get('twitter', 'oauthtoken')
+    os = honeypycfg.get('twitter', 'oauthsecret')
+
+    t = Twitter(auth=OAuth(ot, os, ck, cs))
+    nodename = honeypycfg.get('honeypy', 'nodename')
+
+    try:
+        t.statuses.update(status=nodename + ': #' + service + ' Possible '  + service + ' attack from ' + clientip + ' https://riskdiscovery.com/honeydb/#host/' + clientip)
+    except Exception, err:
+        log.msg('Error posting to Twitter: %s' % err)

--- a/loggers/twitter/honeypy_twitter.py
+++ b/loggers/twitter/honeypy_twitter.py
@@ -7,7 +7,7 @@ from twitter import Twitter
 from twitter.oauth import OAuth
 from twisted.python import log
 
-def process(config, section, parts, time_parts, useragent):
+def process(config, section, parts, time_parts):
         # TCP
         #	parts[0]: date
         #	parts[1]: time_parts


### PR DESCRIPTION
This series of commit moves logger code to the logger folders.
HoneyPy with no longer fail if a loger section is missing from the config.
lib/honeypy_logtail will iterate through enabled loggers and pass event data to the logger for processing.

Also a fair amount of pylint clean-up.

I have only properly tested sumologic logger, but reasonably confident other will work.