### PR TITLE
immediate write to log + disable file log by default

### DIFF
--- a/etc/honeypy.cfg
+++ b/etc/honeypy.cfg
@@ -96,5 +96,5 @@ exchange =
 routing_key =
 
 [file]
-enabled = Yes
+enabled = No
 filename = log/json.log

--- a/loggers/file/honeypy_file.py
+++ b/loggers/file/honeypy_file.py
@@ -82,6 +82,6 @@ def post(config, section, date, time, date_time, millisecond, session, protocol,
     }
 
     if not file:
-        file = open(config.get(section, 'filename'), 'a+')
+        file = open(config.get(section, 'filename'), 'a+', 1)
 
-    file.write(json.dumps(data) + os.linesep).flush()
+    file.write(json.dumps(data) + os.linesep)


### PR DESCRIPTION
```file.write('').flush()``` works in python3, but not in python2 and it doesn't change buffering behavior

