### PR TITLE
Improved logging options

### DIFF
--- a/Honey.py
+++ b/Honey.py
@@ -30,8 +30,9 @@ parser.add_argument('-ipt', help='generate ipt-kit script in /tmp.', default=Fal
 args = parser.parse_args()
 
 # get path for config files
-honeypy_config_file = os.path.dirname(os.path.abspath(__file__)) + '/etc/honeypy.cfg'
-service_config_file = os.path.dirname(os.path.abspath(__file__)) + '/etc/services.cfg'
+script_dir = os.path.dirname(os.path.abspath(__file__))
+honeypy_config_file = script_dir + '/etc/honeypy.cfg'
+service_config_file = script_dir + '/etc/services.cfg'
 
 # setup config parsers
 honeypy_config = ConfigParser.ConfigParser()
@@ -46,10 +47,10 @@ if honeypy_config.has_option('honeypy', 'internal_log_dir'):
     if os.path.isabs(honeypy_config.get('honeypy', 'internal_log_dir')):
         log_path = honeypy_config.get('honeypy', 'internal_log_dir')
     else:
-        log_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), honeypy_config.get('honeypy', 'internal_log_dir'))
+        log_path = os.path.join(script_dir, honeypy_config.get('honeypy', 'internal_log_dir'))
     log_path = os.path.normpath(log_path)
 else:
-    log_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'log/')
+    log_path = os.path.join(script_dir, 'log/')
 
 log_file_name = 'honeypy.log'
 ipt_file_name = '/tmp/honeypy-ipt.sh'
@@ -67,7 +68,7 @@ time_zone = subprocess.check_output(['date', '+%z'])
 file_log_observer.timeFormat = "%Y-%m-%d %H:%M:%S,%f," + time_zone.rstrip()
 
 # get version
-version = file(os.path.dirname(os.path.abspath(__file__)) + '/VERSION').read().strip()
+version = file(script_dir + '/VERSION').read().strip()
 
 # start logging
 log.startLoggingWithObserver(file_log_observer.emit, False)
@@ -77,7 +78,7 @@ if honeypy_config.has_option('honeypy', 'service_profiles'):
     log.msg('Skipping etc/services.cfg')
     service_config = ConfigParser.ConfigParser()
     for service_profile in honeypy_config.get('honeypy', 'service_profiles').split(','):
-        profile_cfg_file = os.path.dirname(os.path.abspath(__file__)) + '/etc/profiles/' + service_profile.strip()
+        profile_cfg_file = script_dir + '/etc/profiles/' + service_profile.strip()
         log.msg("Reading services from %s" % profile_cfg_file)
         profile_cfg = ConfigParser.ConfigParser()
         profile_cfg.read(profile_cfg_file)

--- a/Honey.py
+++ b/Honey.py
@@ -32,9 +32,6 @@ args = parser.parse_args()
 # get path for config files
 honeypy_config_file = os.path.dirname(os.path.abspath(__file__)) + '/etc/honeypy.cfg'
 service_config_file = os.path.dirname(os.path.abspath(__file__)) + '/etc/services.cfg'
-log_path = os.path.dirname(os.path.abspath(__file__)) + '/log/'
-log_file_name = 'honeypy.log'
-ipt_file_name = '/tmp/honeypy-ipt.sh'
 
 # setup config parsers
 honeypy_config = ConfigParser.ConfigParser()
@@ -45,9 +42,21 @@ honeypy_config.read(honeypy_config_file)
 service_config.read(service_config_file)
 
 # setup log file and formatting
-if not os.path.exists(os.path.dirname(log_path)):
+if honeypy_config.has_option('honeypy', 'internal_log_dir'):
+    if os.path.isabs(honeypy_config.get('honeypy', 'internal_log_dir')):
+        log_path = honeypy_config.get('honeypy', 'internal_log_dir')
+    else:
+        log_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), honeypy_config.get('honeypy', 'internal_log_dir'))
+    log_path = os.path.normpath(log_path)
+else:
+    log_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'log/')
+
+log_file_name = 'honeypy.log'
+ipt_file_name = '/tmp/honeypy-ipt.sh'
+
+if not os.path.exists(log_path):
     # if log directory does not exist, create it.
-    os.makedirs(os.path.dirname(log_path))
+    os.makedirs(log_path)
 
 if honeypy_config.get('honeypy', 'limit_internal_logs').lower() == 'yes':
     log_file = SingleDailyLogFile(log_file_name, log_path)
@@ -104,7 +113,7 @@ if args.ipt:
     quit()
 
 # tail log file when reactor runs
-tailer = HoneyPyLogTail(log_path + log_file_name)
+tailer = HoneyPyLogTail(os.path.join(log_path, log_file_name))
 tailer.config = honeypy_config
 tailer.config.set('honeypy', 'useragent', 'HoneyPy (' + version + ')')
 

--- a/Honey.py
+++ b/Honey.py
@@ -107,6 +107,14 @@ if args.ipt:
 tailer = HoneyPyLogTail(log_path + log_file_name)
 tailer.config = honeypy_config
 tailer.config.set('honeypy', 'useragent', 'HoneyPy (' + version + ')')
+
+# set persistent logger connections
+for section in tailer.config.sections():
+    if tailer.config.has_option(section, 'persistent') and tailer.config.get(section, 'persistent').lower() == 'yes' and tailer.config.get(section, 'enabled').lower() == 'yes':
+        module_name = "loggers.%s.honeypy_%s" % (section, section)
+        logger_module = importlib.import_module(module_name)
+        tailer.persistent_conns[section] = logger_module.conn(tailer.config, section)
+
 tailer.start()
 
 log.msg(tailer.config.get('honeypy', 'useragent') + " Started")

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -10,6 +10,7 @@ Name | Description
 ---------- | -------
 nodename | Name for this HoneyPy node to be displayed in tweets, Slack messages, and other integrations.
 limit_internal_logs | Enabling this will ensure that the internal log files are limited to one day, which can be useful for limited deployments e.g. automated containers (e.g. Yes or No).
+internal_log_dir | Directory for internal HoneyPy logs (not external loggers). Use leading slash for absolute path, or omit for relative path. Default: `log/`
 
 ### Loggers
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -4,11 +4,12 @@ There are two configuration files for HoneyPy, both are located in the HoneyPy `
 
 ## HoneyPy
 
-In the `honeypy.cfg` file, the main configuration section is the `[honeypy]` section and actually only has one option to configure.
+In the `honeypy.cfg` file, the main configuration section is the `[honeypy]` section and only has two options to configure.
 
 Name | Description
 ---------- | -------
 nodename | Name for this HoneyPy node to be displayed in tweets, Slack messages, and other integrations.
+limit_internal_logs | Enabling this will ensure that the internal log files are limited to one day, which can be useful for limited deployments e.g. automated containers (e.g. Yes or No).
 
 ### Loggers
 
@@ -82,6 +83,19 @@ consumerkey | Your Twitter consumer key.
 consumersecret | Your Twitter consumer secret.
 oauthtoken | Your Twitter OAuth token.
 oauthsecret | Your Twitter OAuth secret.
+
+#### hpfeeds
+
+Name | Description
+---------- | -------
+enabled | Enable this logger (e.g. Yes or No).
+persistent | Is a persistent connection required (e.g. Yes).
+server | hpfeeds server
+port | hpfeeds port
+ident | hpfeeds ident
+secret | hpfeeds secret
+channel | hpfeeds channel
+serverid | hpfeeds server ID
 
 ## Services
 

--- a/etc/honeypy.cfg
+++ b/etc/honeypy.cfg
@@ -13,6 +13,9 @@ nodename  = honeypy
 #enabling this will disable the use of service.cfg, which will not be processed
 #service_profiles = services.databases.profile, services.linux.profile
 
+# Limit internal log files to a single day. Useful for deployments with limited disk space.
+limit_internal_logs = No
+
 # Tweet events on Twitter. Having a dedicated Twitter account for this purpose is recommended.
 # You will need to Twitter API credentials for this to work. See https://dev.twitter.com/oauth/application-only
 [twitter]

--- a/etc/honeypy.cfg
+++ b/etc/honeypy.cfg
@@ -101,3 +101,13 @@ routing_key =
 [file]
 enabled = No
 filename = log/json.log
+
+[hpfeeds]
+enabled    = No
+persistent = Yes
+server     = 127.0.0.1
+port       = 20000
+ident      = ident
+secret     = secret
+channel    = channel
+serverid   = id

--- a/etc/honeypy.cfg
+++ b/etc/honeypy.cfg
@@ -16,6 +16,10 @@ nodename  = honeypy
 # Limit internal log files to a single day. Useful for deployments with limited disk space.
 limit_internal_logs = No
 
+# Directory for internal HoneyPy logs (not external loggers).
+# Use leading slash for absolute path, or omit for relative path
+internal_log_dir = log/
+
 # Tweet events on Twitter. Having a dedicated Twitter account for this purpose is recommended.
 # You will need to Twitter API credentials for this to work. See https://dev.twitter.com/oauth/application-only
 [twitter]

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -1,7 +1,8 @@
+import os
 from importlib import import_module
 from twisted.python import log
-from lib.followtail import FollowTail
 from twisted.python.logfile import DailyLogFile
+from lib.followtail import FollowTail
 
 class HoneyPyLogTail(FollowTail):
     config = None
@@ -73,7 +74,9 @@ class HoneyPyLogTail(FollowTail):
 
 class SingleDailyLogFile(DailyLogFile):
     def rotate(self):
-        super(SingleDailyLogFile, self).rotate()
-        newpath = "%s.%s" % (self.path, self.suffix(self.lastDate))
-        if os.path.exists(newpath):
-            os.remove(newpath)
+        DailyLogFile.rotate(self)
+        dir = os.path.dirname(self.path)
+        files = os.listdir(dir)
+        for file in files:
+            if file.startswith("honeypy.log."):
+                os.remove(os.path.join(dir, file))

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -1,6 +1,7 @@
 from importlib import import_module
 from twisted.python import log
 from lib.followtail import FollowTail
+from twisted.python.logfile import DailyLogFile
 
 class HoneyPyLogTail(FollowTail):
     config = None
@@ -64,3 +65,11 @@ class HoneyPyLogTail(FollowTail):
 
                     except Exception as e:
                         log.msg('Exception: HoneyPyLogTail: {}: {}'.format(str(e), str(parts)))
+
+
+class SingleDailyLogFile(DailyLogFile):
+    def rotate(self):
+        super(SingleDailyLogFile, self).rotate()
+        newpath = "%s.%s" % (self.path, self.suffix(self.lastDate))
+        if os.path.exists(newpath):
+            os.remove(newpath)

--- a/lib/honeypy_logtail.py
+++ b/lib/honeypy_logtail.py
@@ -5,6 +5,7 @@ from twisted.python.logfile import DailyLogFile
 
 class HoneyPyLogTail(FollowTail):
     config = None
+    persistent_conns = {}
 
     def lineReceived(self, line):
         parts = line.split()
@@ -61,7 +62,10 @@ class HoneyPyLogTail(FollowTail):
                             if section != 'honeypy' and self.config.get(section, 'enabled').lower() == 'yes':
                                 module_name = "loggers.%s.honeypy_%s" % (section, section)
                                 logger_module = import_module(module_name)
-                                logger_module.process(self.config, section, parts, time_parts)
+                                if section in self.persistent_conns:
+                                    logger_module.process(self.config, self.persistent_conns[section], section, parts, time_parts)
+                                else:
+                                    logger_module.process(self.config, section, parts, time_parts)
 
                     except Exception as e:
                         log.msg('Exception: HoneyPyLogTail: {}: {}'.format(str(e), str(parts)))

--- a/loggers/hpfeeds/__init__.py
+++ b/loggers/hpfeeds/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2016 foospidy
+# https://github.com/foospidy/HoneyPy
+# See LICENSE for details
+
+import sys
+# prevent creation of compiled bytecode files
+sys.dont_write_bytecode = True

--- a/loggers/hpfeeds/honeypy_hpfeeds.py
+++ b/loggers/hpfeeds/honeypy_hpfeeds.py
@@ -1,0 +1,120 @@
+# HoneyPy hpfeeds module
+
+import sys
+import hashlib
+from datetime import datetime
+from twisted.python import log
+import json
+import os
+import socket
+
+
+class hpflogger:
+    def __init__(self, hpfserver, hpfport, hpfident, hpfsecret, hpfchannel, serverid):
+        self.hpfserver = hpfserver
+        self.hpfport = hpfport
+        self.hpfident = hpfident
+        self.hpfsecret = hpfsecret
+        self.hpfchannel = hpfchannel
+        self.serverid = serverid
+        self.hpc = None
+        if (self.hpfserver and self.hpfport and self.hpfident and self.hpfport and self.hpfchannel and self.serverid):
+            import logging
+            logging.basicConfig()
+            import hpfeeds
+            try:
+                self.hpc = hpfeeds.new(self.hpfserver, self.hpfport, self.hpfident, self.hpfsecret)
+                self.status = "Logging to hpfeeds using server: {0}, channel {1}.".format(self.hpfserver, self.hpfchannel)
+            except (hpfeeds.FeedException, socket.error, hpfeeds.Disconnect):
+                self.status = "hpfeeds connection not successful"
+    def log(self, message):
+        if self.hpc:
+            message['serverid'] = self.serverid
+            self.hpc.publish(self.hpfchannel, json.dumps(message))
+
+def conn(config, section):
+    environreq = [
+        'HPFEEDS_SERVER',
+        'HPFEEDS_PORT',
+        'HPFEEDS_IDENT',
+        'HPFEEDS_SECRET',
+        'HPFEEDS_CHANNEL',
+        'SERVERID',
+        ]
+    if all(var in os.environ for var in environreq):
+        hpfserver = os.environ.get('HPFEEDS_SERVER')
+        hpfport = int(os.environ.get('HPFEEDS_PORT'))
+        hpfident = os.environ.get('HPFEEDS_IDENT')
+        hpfsecret = os.environ.get('HPFEEDS_SECRET')
+        hpfchannel = os.environ.get('HPFEEDS_CHANNEL')
+        serverid = os.environ.get('SERVERID')
+    else:
+        hpfserver = config.get(section, 'server')
+        hpfport = int(config.get(section, 'port'))
+        hpfident = config.get(section, 'ident')
+        hpfsecret = config.get(section, 'secret')
+        hpfchannel = config.get(section, 'channel')
+        serverid = config.get(section, 'server')
+
+    return hpflogger(hpfserver, hpfport, hpfident, hpfsecret, hpfchannel, serverid)
+
+def process(config, connection, section, parts, time_parts):
+        # TCP
+        #    parts[0]: date
+        #    parts[1]: time_parts
+        #    parts[2]: plugin
+        #    parts[3]: session
+        #    parts[4]: protocol
+        #    parts[5]: event
+        #    parts[6]: local_host
+        #    parts[7]: local_port
+        #    parts[8]: service
+        #    parts[9]: remote_host
+        #    parts[10]: remote_port
+        #    parts[11]: data
+        # UDP
+        #    parts[0]: date
+        #    parts[1]: time_parts
+        #    parts[2]: plugin string part
+        #    parts[3]: plugin string part
+        #    parts[4]: session
+        #    parts[5]: protocol
+        #    parts[6]: event
+        #    parts[7]: local_host
+        #    parts[8]: local_port
+        #    parts[9]: service
+        #    parts[10]: remote_host
+        #    parts[11]: remote_port
+        #    parts[12]: data
+
+    if parts[4] == 'TCP':
+        if len(parts) == 11:
+            parts.append('')  # no data for CONNECT events
+        post(config, section, parts[0], time_parts[0], time_parts[1], parts[3], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], connection)
+    else:
+        # UDP splits differently (see comment section above)
+        if len(parts) == 12:
+            parts.append('')  # no data sent
+        post(config, section, parts[0], time_parts[0], time_parts[1], parts[4], parts[5], parts[6], parts[7], parts[8], parts[9], parts[10], parts[11], parts[12], connection)
+
+
+def post(config, section, date, time, millisecond, session, protocol, event, local_host, local_port, service, remote_host, remote_port, data, connection):
+
+    date_time = date + ' ' + time + '.' + str(millisecond)
+    date_time = datetime.strptime(date_time, "%Y-%m-%d %H:%M:%S.%f").isoformat() + 'Z'
+
+    msg = {
+        'date_time': date_time,
+        'protocol': protocol,
+        'service': service,
+        'dst_host': local_host,
+        'dst_port': local_port,
+        'src_host': remote_host,
+        'src_port': remote_port,
+        'session': session,
+        'event': event,
+        'data': data,
+    }
+
+    # submit log
+    connection.log(msg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ urllib3
 pika == 0.10.0
 pylint
 autopep8
+hpfeeds3 == 0.9.8


### PR DESCRIPTION
This PR is for changes that were made to allow HoneyPy to run in our deployment. In particular:

- A logger for hpfeeds has been added (which required a persistent connection, unlike all other existing loggers)
- 2 new config options were added to give more control over the size and location of honeypy.log